### PR TITLE
feat: package list from file

### DIFF
--- a/nubison_model/Model.py
+++ b/nubison_model/Model.py
@@ -1,8 +1,8 @@
 import mlflow
 
-from os import getenv
+from os import getenv, path
 from sys import version_info as py_version_info
-from typing import Optional, Protocol, runtime_checkable
+from typing import Optional, Protocol, runtime_checkable, List
 from importlib.metadata import distributions
 from mlflow.pyfunc import PythonModel
 
@@ -18,20 +18,44 @@ class Model(Protocol):
     def infer(self, input: any) -> any: ...
 
 
+def _package_list_from_file() -> Optional[List]:
+    # Check if the requirements file exists in order of priority
+    candidates = ["requirements-prod.txt", "requirements.txt"]
+    filename = next((file for file in candidates if path.exists(file)), None)
+
+    if filename is None:
+        return None
+
+    with open(filename, "r") as file:
+        packages = file.readlines()
+    packages = [package.strip() for package in packages if package.strip()]
+    # Remove not sharable dependencies
+    packages = [
+        package
+        for package in packages
+        if not package.startswith(("file:", "./", "../", "/"))
+    ]
+
+    return packages
+
+
+def _package_list_from_env() -> List:
+    # Get the list of installed packages
+    return [
+        f"{dist.metadata['Name']}=={dist.version}"
+        for dist in distributions()
+        if dist.metadata["Name"]
+        is not None  # editable installs have a None metadata name
+    ]
+
+
 def _make_conda_env() -> dict:
     # Get the Python version
     python_version = (
         f"{py_version_info.major}.{py_version_info.minor}.{py_version_info.micro}"
     )
     # Get the list of installed packages
-    packages_list = sorted(
-        [
-            f"{dist.metadata['Name']}=={dist.version}"
-            for dist in distributions()
-            if dist.metadata["Name"]
-            is not None  # editable installs have a None metadata name
-        ]
-    )
+    packages_list = _package_list_from_file() or _package_list_from_env()
 
     return {
         "dependencies": [

--- a/test/fixtures/requirements-prod.txt
+++ b/test/fixtures/requirements-prod.txt
@@ -1,0 +1,6 @@
+pandas==2.0.3
+scikit-learn==1.3.2
+./path/local_package_1
+../path/local_package_2
+/path/local_package_3
+file://path/local_package_4

--- a/test/fixtures/requirements-prod.txt
+++ b/test/fixtures/requirements-prod.txt
@@ -1,6 +1,14 @@
-pandas==2.0.3
-scikit-learn==1.3.2
+# Bad
 ./path/local_package_1
 ../path/local_package_2
 /path/local_package_3
 file://path/local_package_4
+-e git+file://git@github.com/nubison/nubison-model.git
+-r requirements-dev.txt
+-c constraints.txt
+package_name @ file:///path/to/package_name-1.2.3-py3-none-any.whl
+# Good
+pandas==2.0.3
+scikit-learn>=1.3.2
+-e git+ssh://git@github.com/nubison/nubison-model.git
+package_name @ git+https://git.example.com/MyProject

--- a/test/fixtures/requirements.txt
+++ b/test/fixtures/requirements.txt
@@ -1,0 +1,1 @@
+wrong_package==1.0.0

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -7,7 +7,7 @@ from shutil import rmtree
 
 from mlflow.tracking import MlflowClient
 from mlflow.pyfunc import load_model
-from nubison_model.Model import Model, register
+from nubison_model.Model import Model, register, _package_list_from_file
 
 
 @contextmanager
@@ -123,3 +123,12 @@ def test_model_load_artifact_code(mlflow_server):
     with temporary_dirs(["infer"]), temporary_cwd("infer"):
         model = load_model(f"models:/{model_name}/latest")
         assert model.predict("test") == "bartest"
+
+
+def test_package_list_from_file():
+    """
+    Test reading the package list from a requirements.txt file.
+    """
+    with temporary_cwd("test/fixtures"):
+        packages = _package_list_from_file()
+        assert packages == ["pandas==2.0.3", "scikit-learn==1.3.2"]

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -131,4 +131,9 @@ def test_package_list_from_file():
     """
     with temporary_cwd("test/fixtures"):
         packages = _package_list_from_file()
-        assert packages == ["pandas==2.0.3", "scikit-learn==1.3.2"]
+        assert packages == [
+            "pandas==2.0.3",
+            "scikit-learn>=1.3.2",
+            "-e git+ssh://git@github.com/nubison/nubison-model.git",
+            "package_name @ git+https://git.example.com/MyProject",
+        ]


### PR DESCRIPTION
# First, read the package list from files.
If unavailable, fall back to reading it from the current environment as before.
When reading the package list from files, local packages are excluded.

Note: Requirements constraints and nested files (using -c or -r) are not supported.