### PR TITLE
feat: add test client for easy test against server

### DIFF
--- a/nubison_model/__init__.py
+++ b/nubison_model/__init__.py
@@ -8,7 +8,7 @@ from .Model import (
     NubisonModel,
     register,
 )
-from .Service import build_inference_service
+from .Service import build_inference_service, test_client
 
 __all__ = [
     "ENV_VAR_MLFLOW_MODEL_URI",
@@ -16,4 +16,5 @@ __all__ = [
     "NubisonModel",
     "register",
     "build_inference_service",
+    "test_client",
 ]

--- a/nubison_model/utils.py
+++ b/nubison_model/utils.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+from os import chdir, getcwd
+
+
+@contextmanager
+def temporary_cwd(new_dir):
+    original_dir = getcwd()
+    try:
+        chdir(new_dir)
+        yield
+    finally:
+        chdir(original_dir)

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nubison_model import build_inference_service
+from nubison_model import build_inference_service, test_client
 
 
 def test_raise_runtime_error_on_missing_env():
@@ -19,3 +19,20 @@ def test_service_ok():
         mock_load_nubison_model.return_value = DummyModel()
         service = build_inference_service()()
         assert service.infer("test") == "test"
+
+
+def test_client_ok():
+    class DummyModel:
+        def infer(self, test: str):
+            return test
+
+    with patch("nubison_model.Service.load_nubison_model") as mock_load_nubison_model:
+        mock_load_nubison_model.return_value = DummyModel()
+        with test_client("test") as client:
+            response = client.post("/infer", json={"test": "test"})
+            assert response.status_code == 200
+            assert response.text == "test"
+
+
+# Ignore the test_client from being collected by pytest
+setattr(test_client, "__test__", False)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,7 +1,9 @@
 from contextlib import contextmanager
-from os import chdir, environ, getcwd, makedirs, path
+from os import environ, getcwd, makedirs, path
 from shutil import rmtree
-from typing import List, Optional
+from typing import List
+
+from nubison_model.utils import temporary_cwd
 
 
 @contextmanager
@@ -21,16 +23,6 @@ def temporary_dirs(dirs: List[str]):
 
 
 @contextmanager
-def temporary_cwd(new_dir):
-    original_dir = getcwd()
-    try:
-        chdir(new_dir)
-        yield
-    finally:
-        chdir(original_dir)
-
-
-@contextmanager
 def temporary_env(env: dict):
     original_env = environ.copy()
     for key, value in env.items():
@@ -40,3 +32,6 @@ def temporary_env(env: dict):
 
     environ.clear()
     environ.update(original_env)
+
+
+__all__ = ["temporary_cwd", "temporary_dirs", "temporary_env"]


### PR DESCRIPTION
# Brought the simplest way to test inference server

## Register the test model
```python
from nubison_model import NubisonModel, register

class UserModel(NubisonModel):
    def infer(self, txt: str):
        return {"result": str(txt)}

model_id = register(UserModel())
```

## Now test it as http inference server!
```python
from nubison_model.Service import test_client

with test_client(model_id) as client:
    result = client.post("/infer", json={"txt": "test text"})
    print(result.status_code)
    print(result.json())
```
**That's It!** 
No need to start server manually. No need to write stubbing code for the client.