### PR TITLE
feat: load model once on service prepare

### DIFF
--- a/fixtures
+++ b/fixtures
@@ -1,0 +1,1 @@
+/tmp/tmpbeyst168/0/b52728cee108496e85011e0b71ed4f3b/artifacts/artifacts/fixtures

--- a/nubison_model/Model.py
+++ b/nubison_model/Model.py
@@ -46,7 +46,7 @@ class NubisonMLFlowModel(PythonModel):
                 print(f"Error creating symlink for {name}: {e}")
 
     def load_context(self, context: Any) -> None:
-        """Make the MLFlow artifact is accessible to the model in the same way as in the local environment
+        """Make the MLFlow artifact accessible to the model in the same way as in the local environment
 
         Args:
             context (PythonModelContext): A collection of artifacts that a PythonModel can use when performing inference.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -64,35 +64,6 @@ def test_throw_on_model_not_implementing_protocol(mlflow_server):
     register(RightModel())
 
 
-def test_model_load_artifact_code(mlflow_server):
-    """
-    Test loading the artifact code paths.
-    """
-    model_name = "TestRegisteredModel"
-
-    class DummyModel(NubisonModel):
-        def load_model(self):
-            # Try to read the contents of the artifact file
-            with open("./fixtures/bar.txt", "r") as f:
-                self.loaded = f.read()
-
-        def infer(self, param1):
-            # Try to import a function from the artifact code
-            from .fixtures.poo import echo
-
-            return echo(self.loaded + param1)
-
-    # Switch cwd to the current file directory to register the fixture artifact
-    with temporary_cwd("test"):
-        register(DummyModel(), model_name=model_name, artifact_dirs="fixtures")
-
-    # Create temp dir and switch to it to test the model.
-    # So artifact symlink not to coliide with the current directory
-    with temporary_dirs(["infer"]), temporary_cwd("infer"):
-        model = load_model(f"models:/{model_name}/latest")
-        assert model.predict({"input": {"param1": "test"}}) == "bartest"
-
-
 def test_package_list_from_file():
     """
     Test reading the package list from a requirements.txt file.


### PR DESCRIPTION
The goal is to remove the unnecessary "initialize" parameter from MLflow and its logs in the multiprocess server. This approach improves upon the previous implementation, which relied on the experimental MLflow feature "model config." Now, the model is prepared once during loading nubison model globally, regardless of how many server processes are running.