### PR TITLE
fix: test_client fails due to lmodel loading wrong way

### DIFF
--- a/nubison_model/__init__.py
+++ b/nubison_model/__init__.py
@@ -5,6 +5,7 @@ __version__ = "0.0.0"
 from .Model import (
     ENV_VAR_MLFLOW_MODEL_URI,
     ENV_VAR_MLFLOW_TRACKING_URI,
+    NubisonMLFlowModel,
     NubisonModel,
     register,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "ENV_VAR_MLFLOW_MODEL_URI",
     "ENV_VAR_MLFLOW_TRACKING_URI",
     "NubisonModel",
+    "NubisonMLFlowModel",
     "register",
     "build_inference_service",
     "test_client",

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,6 +1,7 @@
 from nubison_model import (
     ENV_VAR_MLFLOW_MODEL_URI,
     NubisonModel,
+    Service,
     build_inference_service,
     register,
 )
@@ -35,3 +36,32 @@ def test_register_and_serve_model(mlflow_server):
     ):
         bento_service = build_inference_service()()
         assert bento_service.infer("test") == "bartest"
+
+
+def test_register_and_test_model(mlflow_server):
+    """
+    Test registering a model to MLflow's Model Registry and testing it with BentoML.
+    """
+
+    class DummyModel(NubisonModel):
+        def load_model(self):
+            # Try to read the contents of the artifact file
+            with open("./fixtures/bar.txt", "r") as f:
+                self.loaded = f.read()
+
+        def infer(self, param1: str):
+            # Try to import a function from the artifact code
+            from .fixtures.poo import echo
+
+            return echo(self.loaded + param1)
+
+    # Switch cwd to the current file directory to register the fixture artifact
+    with temporary_cwd("test"):
+        model_uri = register(DummyModel(), artifact_dirs="fixtures")
+
+    # Create temp dir and switch to it to test the model.
+    # So artifact symlink not to coliide with the current directory
+    with Service.test_client(model_uri) as client:
+        response = client.post("/infer", json={"param1": "test"})
+        assert response.status_code == 200
+        assert response.text == "bartest"

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nubison_model import build_inference_service, test_client
+from nubison_model import NubisonMLFlowModel, build_inference_service, test_client
 
 
 def test_raise_runtime_error_on_missing_env():
@@ -15,8 +15,13 @@ def test_service_ok():
         def infer(self, test: str):
             return test
 
-    with patch("nubison_model.Service.load_nubison_model") as mock_load_nubison_model:
-        mock_load_nubison_model.return_value = DummyModel()
+        def load_model(self):
+            pass
+
+    with patch(
+        "nubison_model.Service.load_nubison_mlflow_model"
+    ) as mock_load_nubison_mlflow_model:
+        mock_load_nubison_mlflow_model.return_value = NubisonMLFlowModel(DummyModel())
         service = build_inference_service()()
         assert service.infer("test") == "test"
 
@@ -26,8 +31,13 @@ def test_client_ok():
         def infer(self, test: str):
             return test
 
-    with patch("nubison_model.Service.load_nubison_model") as mock_load_nubison_model:
-        mock_load_nubison_model.return_value = DummyModel()
+        def load_model(self):
+            pass
+
+    with patch(
+        "nubison_model.Service.load_nubison_mlflow_model"
+    ) as mock_load_nubison_mlflow_model:
+        mock_load_nubison_mlflow_model.return_value = NubisonMLFlowModel(DummyModel())
         with test_client("test") as client:
             response = client.post("/infer", json={"test": "test"})
             assert response.status_code == 200


### PR DESCRIPTION
The recent change in the model loading process caused the test_client to break. The test_client was not prepared for the loaded artifacts. While fixing the bug, I improved the model loading process by implementing the following changes:
- Prepare artifacts earlier in the workflow.
- Allow model loading to occur independently from the artifact preparation state.
- Ensure that NubisonMLFlowModel delegates to NubisonModel, rather than exposing the raw NubisonModel directly.