### PR TITLE
fix: update shell script to handle MLflow IP blocking #14

### DIFF
--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -20,7 +20,7 @@ echo "MLFLOW_TRACKING_URI: '$MLFLOW_TRACKING_URI'"
 echo "MLFLOW_MODEL_URI: '$MLFLOW_MODEL_URI'"
 echo "NUM_WORKERS: '$NUM_WORKERS'"
 
-response_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 "${MLFLOW_TRACKING_URI}" || echo "000")
+response_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 -f "${MLFLOW_TRACKING_URI}" || echo "000")
 if [ "$response_code" -ne 200 ]; then
   echo "Failed to connect to the MLflow server"
   exit 1

--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -20,17 +20,14 @@ echo "MLFLOW_TRACKING_URI: '$MLFLOW_TRACKING_URI'"
 echo "MLFLOW_MODEL_URI: '$MLFLOW_MODEL_URI'"
 echo "NUM_WORKERS: '$NUM_WORKERS'"
 
-response_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 -f "${MLFLOW_TRACKING_URI}" || echo "000")
-if [ "$response_code" -ne 200 ]; then
-  echo "Failed to connect to the MLflow server"
-  exit 1
-else
-  echo "Server is up"
-fi
-
 echo "Downloading conda.yaml & requirements.txt for run $run_uuid"
-curl -L -o conda.yaml "${MLFLOW_TRACKING_URI}/get-artifact?path=conda.yaml&run_uuid=${run_uuid}"
-curl -L -o requirements.txt "${MLFLOW_TRACKING_URI}/get-artifact?path=requirements.txt&run_uuid=${run_uuid}"
+ret_conda=$(curl -L -o conda.yaml -f "${MLFLOW_TRACKING_URI}/get-artifact?path=conda.yaml&run_uuid=${run_uuid}")
+ret_req=$(curl -L -o requirements.txt -f "${MLFLOW_TRACKING_URI}/get-artifact?path=requirements.txt&run_uuid=${run_uuid}")
+
+if [ "$ret_conda" -ne 200 ] || [ "$ret_req" -ne 200 ]; then
+  echo "Failed to download conda.yaml or requirements.txt"
+  exit 1
+fi
 
 python_version=$(grep "python=" conda.yaml | awk -F= '{print $2}')
 

--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -20,6 +20,12 @@ echo "MLFLOW_TRACKING_URI: '$MLFLOW_TRACKING_URI'"
 echo "MLFLOW_MODEL_URI: '$MLFLOW_MODEL_URI'"
 echo "NUM_WORKERS: '$NUM_WORKERS'"
 
+response_code=$(curl -s -o /dev/null -w "%{http_code}" -L "${MLFLOW_TRACKING_URI}/get-artifact?path=conda.yaml&run_uuid=${run_uuid}")
+echo "HTTP Status Code: $response_code"
+if [ "$response_code" -ne 200 ]; then
+  exit 1
+fi
+
 echo "Downloading conda.yaml & requirements.txt for run $run_uuid"
 curl -L -o conda.yaml "${MLFLOW_TRACKING_URI}/get-artifact?path=conda.yaml&run_uuid=${run_uuid}"
 curl -L -o requirements.txt "${MLFLOW_TRACKING_URI}/get-artifact?path=requirements.txt&run_uuid=${run_uuid}"

--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -20,10 +20,12 @@ echo "MLFLOW_TRACKING_URI: '$MLFLOW_TRACKING_URI'"
 echo "MLFLOW_MODEL_URI: '$MLFLOW_MODEL_URI'"
 echo "NUM_WORKERS: '$NUM_WORKERS'"
 
-response_code=$(curl -s -o /dev/null -w "%{http_code}" -L "${MLFLOW_TRACKING_URI}/get-artifact?path=conda.yaml&run_uuid=${run_uuid}")
-echo "HTTP Status Code: $response_code"
+response_code=$(curl -s -o /dev/null -w "%{http_code}" "${MLFLOW_TRACKING_URI}" || echo "000")
 if [ "$response_code" -ne 200 ]; then
+  echo "Failed to connect to the MLflow server"
   exit 1
+else
+  echo "Server is up"
 fi
 
 echo "Downloading conda.yaml & requirements.txt for run $run_uuid"

--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -20,7 +20,7 @@ echo "MLFLOW_TRACKING_URI: '$MLFLOW_TRACKING_URI'"
 echo "MLFLOW_MODEL_URI: '$MLFLOW_MODEL_URI'"
 echo "NUM_WORKERS: '$NUM_WORKERS'"
 
-response_code=$(curl -s -o /dev/null -w "%{http_code}" "${MLFLOW_TRACKING_URI}" || echo "000")
+response_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 "${MLFLOW_TRACKING_URI}" || echo "000")
 if [ "$response_code" -ne 200 ]; then
   echo "Failed to connect to the MLflow server"
   exit 1


### PR DESCRIPTION
This is related to issue #14.

**Description:**
This PR updates the shell script to properly handle cases where the MLflow server IP is blocked. Previously, there was no warning message, making it difficult to identify errors. With this fix:
- The script now checks the response status code.
- It proceeds only if the status code is 200.
- If the status code is not 200, an error message is displayed, and execution is stopped.

**Changes:**
Modified the shell script to include status code validation.
Added error handling to stop execution when the MLflow server is unreachable.

**Related Issues:**
Fixes issue related to missing error handling when the MLflow server IP is blocked.
