### PR TITLE
fix: prevent duplicate MLflow artifact download in BentoML

### DIFF
--- a/nubison_model/Service.py
+++ b/nubison_model/Service.py
@@ -25,7 +25,7 @@ ENV_VAR_NUM_WORKERS = "NUM_WORKERS"
 DEFAULT_NUM_WORKERS = 1
 
 
-def get_shared_artifacts_dir():
+def _get_shared_artifacts_dir():
     """Get the shared artifacts directory path (OS-compatible)."""
     return os.path.join(tempfile.gettempdir(), "nubison_shared_artifacts")
 
@@ -80,7 +80,7 @@ def load_nubison_mlflow_model(mlflow_tracking_uri, mlflow_model_uri):
     if not mlflow_tracking_uri or not mlflow_model_uri:
         raise RuntimeError("MLflow tracking URI and model URI must be set")
 
-    shared_info_dir = get_shared_artifacts_dir()
+    shared_info_dir = _get_shared_artifacts_dir()
     lock_file = shared_info_dir + ".lock"
     path_file = shared_info_dir + ".path"
 

--- a/nubison_model/Service.py
+++ b/nubison_model/Service.py
@@ -77,6 +77,28 @@ def _extract_and_cache_model_path(mlflow_model, path_file):
 
 
 def load_nubison_mlflow_model(mlflow_tracking_uri, mlflow_model_uri):
+    """Load a Nubison MLflow model with robust caching and multi-worker support.
+
+    This function implements a sophisticated model loading strategy that uses FileLock
+    for inter-process synchronization, ensuring only one worker downloads the model
+    while others wait and reuse the cached result. Includes automatic timeout handling
+    and fallback mechanisms for production reliability.
+
+    Args:
+        mlflow_tracking_uri (str): MLflow tracking server URI for model registry access
+        mlflow_model_uri (str): Model URI in MLflow format (e.g., 'models:/model_name/version')
+
+    Returns:
+        NubisonMLFlowModel: Loaded and wrapped model ready for inference
+
+    Raises:
+        RuntimeError: If required URIs are not provided
+        Timeout: If lock acquisition times out (handled with fallback)
+
+    Note:
+        Uses 5-minute timeout and double-check pattern to prevent race conditions.
+        Automatically extracts and caches local model paths for faster subsequent loads.
+    """
     if not mlflow_tracking_uri or not mlflow_model_uri:
         raise RuntimeError("MLflow tracking URI and model URI must be set")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 python = ">=3.9,<3.13"
 mlflow = "^2.17.0"
 bentoml = "^1.3.10"
+filelock = "^3.16.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -1,4 +1,8 @@
-from unittest.mock import patch
+import os
+import tempfile
+import threading
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL.Image import Image
@@ -10,7 +14,7 @@ from nubison_model import (
     build_inference_service,
     test_client,
 )
-from nubison_model.Service import DEFAULT_NUM_WORKERS
+from nubison_model.Service import DEFAULT_NUM_WORKERS, load_nubison_mlflow_model
 from test.utils import temporary_env
 
 
@@ -116,6 +120,263 @@ def test_model_context():
                 "worker_index": 0,
                 "num_workers": 1,
             }, "When worker_index is unavailable, both worker_index and num_workers should be set to 1"
+
+
+def test_artifact_sharing_basic():
+    """Test basic artifact sharing functionality."""
+    from nubison_model.Service import get_shared_artifacts_dir
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "nubison_model.Service.get_shared_artifacts_dir", return_value=temp_dir
+        ):
+            # Test path file operations
+            path_file = temp_dir + ".path"
+            test_path = "/test/model/path"
+
+            # Simulate first worker saving path
+            with open(path_file, "w") as f:
+                f.write(test_path)
+
+            # Simulate second worker reading path
+            with open(path_file, "r") as f:
+                cached_path = f.read().strip()
+
+            assert cached_path == test_path
+
+
+def test_lock_directory_creation():
+    """Test lock directory creation and cleanup."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        lock_dir = os.path.join(temp_dir, "test.lock")
+
+        # Test lock creation
+        try:
+            os.makedirs(lock_dir, exist_ok=False)
+            assert os.path.exists(lock_dir)
+
+            # Test lock cleanup
+            os.rmdir(lock_dir)
+            assert not os.path.exists(lock_dir)
+        except FileExistsError:
+            pytest.fail("Lock directory should not exist initially")
+
+
+def test_concurrent_lock_behavior():
+    """Test concurrent lock acquisition behavior."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        lock_dir = os.path.join(temp_dir, "test.lock")
+
+        # First thread should succeed
+        try:
+            os.makedirs(lock_dir, exist_ok=False)
+            lock_acquired = True
+        except FileExistsError:
+            lock_acquired = False
+
+        assert lock_acquired, "First lock attempt should succeed"
+
+        # Second attempt should fail
+        try:
+            os.makedirs(lock_dir, exist_ok=False)
+            second_lock_acquired = True
+        except FileExistsError:
+            second_lock_acquired = False
+
+        assert not second_lock_acquired, "Second lock attempt should fail"
+
+        # Cleanup
+        os.rmdir(lock_dir)
+
+
+def test_fallback_on_missing_uris():
+    """Test that proper errors are raised when URIs are missing."""
+    with pytest.raises(
+        RuntimeError, match="MLflow tracking URI and model URI must be set"
+    ):
+        load_nubison_mlflow_model("", "test_model")
+
+    with pytest.raises(
+        RuntimeError, match="MLflow tracking URI and model URI must be set"
+    ):
+        load_nubison_mlflow_model("http://test", "")
+
+
+def test_load_nubison_mlflow_model_single_worker():
+    """Test load_nubison_mlflow_model with single worker scenario."""
+
+    class MockNubisonModel:
+        def infer(self, test: str):
+            return test
+
+        def load_model(self, context):
+            pass
+
+    class MockMLflowModel:
+        def __init__(self, model_path):
+            self.model_path = model_path
+            self._model_impl = self
+            self.context = MagicMock()
+            self.context.artifacts = {"model": model_path}
+
+        def unwrap_python_model(self):
+            return NubisonMLFlowModel(MockNubisonModel())
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        model_path = os.path.join(temp_dir, "model", "artifacts", "model_file")
+        os.makedirs(os.path.dirname(model_path), exist_ok=True)
+        with open(model_path, "w") as f:
+            f.write("test model")
+
+        # Create MLmodel file in the expected location
+        mlmodel_path = os.path.join(temp_dir, "model", "MLmodel")
+        with open(mlmodel_path, "w") as f:
+            f.write("test mlmodel")
+
+        with patch(
+            "nubison_model.Service.get_shared_artifacts_dir",
+            return_value=os.path.join(temp_dir, "shared"),
+        ):
+            with patch("nubison_model.Service.set_tracking_uri"):
+                with patch(
+                    "nubison_model.Service.load_model",
+                    return_value=MockMLflowModel(model_path),
+                ):
+                    result = load_nubison_mlflow_model("http://test", "model_uri")
+                    assert isinstance(result, NubisonMLFlowModel)
+
+                    # Verify path file was created
+                    path_file = os.path.join(temp_dir, "shared") + ".path"
+                    assert os.path.exists(path_file)
+                    with open(path_file, "r") as f:
+                        cached_path = f.read().strip()
+                    assert cached_path == os.path.join(temp_dir, "model")
+
+
+def test_load_nubison_mlflow_model_lock_mechanism():
+    """Test that load_nubison_mlflow_model implements proper lock mechanism."""
+
+    class MockNubisonModel:
+        def infer(self, test: str):
+            return test
+
+        def load_model(self, context):
+            pass
+
+    class MockMLflowModel:
+        def __init__(self, model_path):
+            self.model_path = model_path
+            self._model_impl = self
+            self.context = MagicMock()
+            self.context.artifacts = {"model": model_path}
+
+        def unwrap_python_model(self):
+            return NubisonMLFlowModel(MockNubisonModel())
+
+    called_uris = []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        def mock_load_model(model_uri):
+            called_uris.append(model_uri)
+            # Return the actual artifact path that exists on disk
+            return MockMLflowModel(
+                os.path.join(temp_dir, "model", "artifacts", "model_file")
+            )
+
+        # Create proper directory structure that mimics MLflow artifacts
+        model_root = os.path.join(temp_dir, "model")
+        artifacts_dir = os.path.join(model_root, "artifacts")
+        model_path = os.path.join(artifacts_dir, "model_file")
+
+        os.makedirs(artifacts_dir, exist_ok=True)
+        with open(model_path, "w") as f:
+            f.write("test model")
+
+        # Create MLmodel file in model root
+        mlmodel_path = os.path.join(model_root, "MLmodel")
+        with open(mlmodel_path, "w") as f:
+            f.write("test mlmodel")
+
+        shared_dir = os.path.join(temp_dir, "shared")
+
+        with patch(
+            "nubison_model.Service.get_shared_artifacts_dir", return_value=shared_dir
+        ):
+            with patch("nubison_model.Service.set_tracking_uri"):
+                with patch(
+                    "nubison_model.Service.load_model", side_effect=mock_load_model
+                ):
+                    # First call should download and create cache
+                    result1 = load_nubison_mlflow_model("http://test", "model_uri")
+                    assert isinstance(result1, NubisonMLFlowModel)
+                    assert len(called_uris) == 1
+                    assert called_uris[0] == "model_uri"
+
+                    # Path file should exist with the model root path
+                    path_file = shared_dir + ".path"
+                    assert os.path.exists(path_file)
+
+                    with open(path_file, "r") as f:
+                        cached_path = f.read().strip()
+                    assert cached_path == model_root
+
+                    # Second call should use cached path
+                    result2 = load_nubison_mlflow_model("http://test", "model_uri")
+                    assert isinstance(result2, NubisonMLFlowModel)
+
+                    # Second call should load from cached path, not original URI
+                    assert len(called_uris) == 2
+                    assert (
+                        called_uris[1] == model_root
+                    )  # This should be the cached path
+
+
+def test_load_nubison_mlflow_model_uses_cached_path():
+    """Test that subsequent calls use cached path without downloading."""
+
+    class MockNubisonModel:
+        def infer(self, test: str):
+            return test
+
+        def load_model(self, context):
+            pass
+
+    download_count = 0
+
+    def mock_load_model(model_uri):
+        nonlocal download_count
+        download_count += 1
+        return MagicMock()
+
+    def mock_load_model_wrapper(tracking_uri, model_uri):
+        return NubisonMLFlowModel(MockNubisonModel())
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        shared_dir = os.path.join(temp_dir, "shared")
+        path_file = shared_dir + ".path"
+        cached_path = "/cached/model/path"
+
+        # Pre-create cached path file
+        with open(path_file, "w") as f:
+            f.write(cached_path)
+
+        with patch(
+            "nubison_model.Service.get_shared_artifacts_dir", return_value=shared_dir
+        ):
+            with patch("nubison_model.Service.load_model", side_effect=mock_load_model):
+                with patch(
+                    "nubison_model.Service._load_model_with_nubison_wrapper",
+                    side_effect=mock_load_model_wrapper,
+                ) as mock_wrapper:
+                    result = load_nubison_mlflow_model("http://test", "original_uri")
+
+                    # Should use cached path, not original URI
+                    mock_wrapper.assert_called_once_with("http://test", cached_path)
+                    assert isinstance(result, NubisonMLFlowModel)
+
+                    # No downloads should have occurred
+                    assert download_count == 0
 
 
 # Ignore the test_client from being collected by pytest

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -5,6 +5,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from filelock import FileLock, Timeout
 from PIL.Image import Image
 from PIL.Image import open as open_image
 
@@ -14,7 +15,10 @@ from nubison_model import (
     build_inference_service,
     test_client,
 )
-from nubison_model.Service import DEFAULT_NUM_WORKERS, load_nubison_mlflow_model
+from nubison_model.Service import (
+    DEFAULT_NUM_WORKERS,
+    load_nubison_mlflow_model,
+)
 from test.utils import temporary_env
 
 
@@ -122,84 +126,90 @@ def test_model_context():
             }, "When worker_index is unavailable, both worker_index and num_workers should be set to 1"
 
 
-def test_artifact_sharing_basic():
-    """Test basic artifact sharing functionality."""
-    from nubison_model.Service import get_shared_artifacts_dir
+def test_filelock_concurrent_access():
+    """Test FileLock prevents concurrent access between threads."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        lock_file = os.path.join(temp_dir, "test.lock")
+        lock1 = FileLock(lock_file, timeout=0.1)
+        lock2 = FileLock(lock_file, timeout=0.1)
+
+        results = []
+
+        def worker1():
+            try:
+                with lock1:
+                    results.append("worker1_acquired")
+                    time.sleep(0.2)  # Hold lock for 200ms
+                    results.append("worker1_released")
+            except Timeout:
+                results.append("worker1_timeout")
+
+        def worker2():
+            time.sleep(0.05)  # Start slightly after worker1
+            try:
+                with lock2:
+                    results.append("worker2_acquired")
+                    results.append("worker2_released")
+            except Timeout:
+                results.append("worker2_timeout")
+
+        thread1 = threading.Thread(target=worker1)
+        thread2 = threading.Thread(target=worker2)
+
+        thread1.start()
+        thread2.start()
+
+        thread1.join()
+        thread2.join()
+
+        # Worker2 should timeout because worker1 holds the lock
+        assert "worker1_acquired" in results
+        assert "worker1_released" in results
+        assert "worker2_timeout" in results
+
+
+def test_filelock_timeout_fallback_integration():
+    """Test timeout fallback in load_nubison_mlflow_model."""
+
+    class MockNubisonModel:
+        def infer(self, test: str):
+            return test
+
+        def load_model(self, context):
+            pass
+
+    fallback_calls = []
+
+    def mock_load_model_wrapper(tracking_uri, model_uri):
+        fallback_calls.append(model_uri)
+        return MagicMock(), NubisonMLFlowModel(MockNubisonModel())
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        shared_dir = os.path.join(temp_dir, "shared")
+
         with patch(
-            "nubison_model.Service.get_shared_artifacts_dir", return_value=temp_dir
+            "nubison_model.Service._get_shared_artifacts_dir", return_value=shared_dir
         ):
-            # Test path file operations
-            path_file = temp_dir + ".path"
-            test_path = "/test/model/path"
+            with patch(
+                "nubison_model.Service._load_cached_model_if_available",
+                return_value=None,
+            ):
+                with patch(
+                    "nubison_model.Service._load_model_with_nubison_wrapper",
+                    side_effect=mock_load_model_wrapper,
+                ):
+                    with patch("nubison_model.Service.FileLock") as mock_filelock_class:
+                        # Mock FileLock to raise Timeout
+                        mock_filelock = MagicMock()
+                        mock_filelock.__enter__.side_effect = Timeout("test.lock")
+                        mock_filelock_class.return_value = mock_filelock
 
-            # Simulate first worker saving path
-            with open(path_file, "w") as f:
-                f.write(test_path)
+                        result = load_nubison_mlflow_model("http://test", "model_uri")
 
-            # Simulate second worker reading path
-            with open(path_file, "r") as f:
-                cached_path = f.read().strip()
-
-            assert cached_path == test_path
-
-
-def test_lock_directory_creation():
-    """Test lock directory creation and cleanup."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        lock_dir = os.path.join(temp_dir, "test.lock")
-
-        # Test lock creation
-        try:
-            os.makedirs(lock_dir, exist_ok=False)
-            assert os.path.exists(lock_dir)
-
-            # Test lock cleanup
-            os.rmdir(lock_dir)
-            assert not os.path.exists(lock_dir)
-        except FileExistsError:
-            pytest.fail("Lock directory should not exist initially")
-
-
-def test_concurrent_lock_behavior():
-    """Test concurrent lock acquisition behavior."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        lock_dir = os.path.join(temp_dir, "test.lock")
-
-        # First thread should succeed
-        try:
-            os.makedirs(lock_dir, exist_ok=False)
-            lock_acquired = True
-        except FileExistsError:
-            lock_acquired = False
-
-        assert lock_acquired, "First lock attempt should succeed"
-
-        # Second attempt should fail
-        try:
-            os.makedirs(lock_dir, exist_ok=False)
-            second_lock_acquired = True
-        except FileExistsError:
-            second_lock_acquired = False
-
-        assert not second_lock_acquired, "Second lock attempt should fail"
-
-        # Cleanup
-        os.rmdir(lock_dir)
-
-
-def test_fallback_on_missing_uris():
-    """Test that proper errors are raised when URIs are missing."""
-    with pytest.raises(
-        RuntimeError, match="MLflow tracking URI and model URI must be set"
-    ):
-        load_nubison_mlflow_model("", "test_model")
-
-    with pytest.raises(
-        RuntimeError, match="MLflow tracking URI and model URI must be set"
-    ):
-        load_nubison_mlflow_model("http://test", "")
+                        # Should fall back to original URI
+                        assert len(fallback_calls) == 1
+                        assert fallback_calls[0] == "model_uri"
+                        assert isinstance(result, NubisonMLFlowModel)
 
 
 def test_load_nubison_mlflow_model_single_worker():
@@ -234,7 +244,7 @@ def test_load_nubison_mlflow_model_single_worker():
             f.write("test mlmodel")
 
         with patch(
-            "nubison_model.Service.get_shared_artifacts_dir",
+            "nubison_model.Service._get_shared_artifacts_dir",
             return_value=os.path.join(temp_dir, "shared"),
         ):
             with patch("nubison_model.Service.set_tracking_uri"):
@@ -253,8 +263,8 @@ def test_load_nubison_mlflow_model_single_worker():
                     assert cached_path == os.path.join(temp_dir, "model")
 
 
-def test_load_nubison_mlflow_model_lock_mechanism():
-    """Test that load_nubison_mlflow_model implements proper lock mechanism."""
+def test_corrupted_cache_file_handling():
+    """Test handling of corrupted or invalid cache files."""
 
     class MockNubisonModel:
         def infer(self, test: str):
@@ -263,120 +273,128 @@ def test_load_nubison_mlflow_model_lock_mechanism():
         def load_model(self, context):
             pass
 
-    class MockMLflowModel:
-        def __init__(self, model_path):
-            self.model_path = model_path
-            self._model_impl = self
-            self.context = MagicMock()
-            self.context.artifacts = {"model": model_path}
-
-        def unwrap_python_model(self):
-            return NubisonMLFlowModel(MockNubisonModel())
-
-    called_uris = []
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-
-        def mock_load_model(model_uri):
-            called_uris.append(model_uri)
-            # Return the actual artifact path that exists on disk
-            return MockMLflowModel(
-                os.path.join(temp_dir, "model", "artifacts", "model_file")
-            )
-
-        # Create proper directory structure that mimics MLflow artifacts
-        model_root = os.path.join(temp_dir, "model")
-        artifacts_dir = os.path.join(model_root, "artifacts")
-        model_path = os.path.join(artifacts_dir, "model_file")
-
-        os.makedirs(artifacts_dir, exist_ok=True)
-        with open(model_path, "w") as f:
-            f.write("test model")
-
-        # Create MLmodel file in model root
-        mlmodel_path = os.path.join(model_root, "MLmodel")
-        with open(mlmodel_path, "w") as f:
-            f.write("test mlmodel")
-
-        shared_dir = os.path.join(temp_dir, "shared")
-
-        with patch(
-            "nubison_model.Service.get_shared_artifacts_dir", return_value=shared_dir
-        ):
-            with patch("nubison_model.Service.set_tracking_uri"):
-                with patch(
-                    "nubison_model.Service.load_model", side_effect=mock_load_model
-                ):
-                    # First call should download and create cache
-                    result1 = load_nubison_mlflow_model("http://test", "model_uri")
-                    assert isinstance(result1, NubisonMLFlowModel)
-                    assert len(called_uris) == 1
-                    assert called_uris[0] == "model_uri"
-
-                    # Path file should exist with the model root path
-                    path_file = shared_dir + ".path"
-                    assert os.path.exists(path_file)
-
-                    with open(path_file, "r") as f:
-                        cached_path = f.read().strip()
-                    assert cached_path == model_root
-
-                    # Second call should use cached path
-                    result2 = load_nubison_mlflow_model("http://test", "model_uri")
-                    assert isinstance(result2, NubisonMLFlowModel)
-
-                    # Second call should load from cached path, not original URI
-                    assert len(called_uris) == 2
-                    assert (
-                        called_uris[1] == model_root
-                    )  # This should be the cached path
-
-
-def test_load_nubison_mlflow_model_uses_cached_path():
-    """Test that subsequent calls use cached path without downloading."""
-
-    class MockNubisonModel:
-        def infer(self, test: str):
-            return test
-
-        def load_model(self, context):
-            pass
-
-    download_count = 0
-
-    def mock_load_model(model_uri):
-        nonlocal download_count
-        download_count += 1
-        return MagicMock()
+    fallback_calls = []
 
     def mock_load_model_wrapper(tracking_uri, model_uri):
-        return NubisonMLFlowModel(MockNubisonModel())
+        fallback_calls.append(model_uri)
+        return MagicMock(), NubisonMLFlowModel(MockNubisonModel())
 
     with tempfile.TemporaryDirectory() as temp_dir:
         shared_dir = os.path.join(temp_dir, "shared")
         path_file = shared_dir + ".path"
-        cached_path = "/cached/model/path"
 
-        # Pre-create cached path file
+        # Test 1: Cache file points to non-existent path
         with open(path_file, "w") as f:
-            f.write(cached_path)
+            f.write("/non/existent/path")
 
         with patch(
-            "nubison_model.Service.get_shared_artifacts_dir", return_value=shared_dir
+            "nubison_model.Service._get_shared_artifacts_dir", return_value=shared_dir
         ):
-            with patch("nubison_model.Service.load_model", side_effect=mock_load_model):
+            with patch(
+                "nubison_model.Service._load_model_with_nubison_wrapper",
+                side_effect=mock_load_model_wrapper,
+            ) as mock_wrapper:
+                # First call should try cached path and fail, then fallback to original URI
+                def side_effect_cached_failure(tracking_uri, model_uri):
+                    if model_uri == "/non/existent/path":
+                        raise FileNotFoundError("Model file not found")
+                    return mock_load_model_wrapper(tracking_uri, model_uri)
+
+                mock_wrapper.side_effect = side_effect_cached_failure
+
+                # Should handle the cached path failure and fallback to original URI
+                with pytest.raises(FileNotFoundError):
+                    load_nubison_mlflow_model("http://test", "model_uri")
+
+        # Test 2: Empty cache file
+        fallback_calls.clear()
+        with open(path_file, "w") as f:
+            f.write("")
+
+        with patch(
+            "nubison_model.Service._get_shared_artifacts_dir", return_value=shared_dir
+        ):
+            with patch(
+                "nubison_model.Service._load_model_with_nubison_wrapper",
+                side_effect=mock_load_model_wrapper,
+            ) as mock_wrapper:
+
+                def side_effect_empty_path(tracking_uri, model_uri):
+                    if model_uri == "":
+                        raise ValueError("Empty model path")
+                    return mock_load_model_wrapper(tracking_uri, model_uri)
+
+                mock_wrapper.side_effect = side_effect_empty_path
+
+                with pytest.raises(ValueError):
+                    load_nubison_mlflow_model("http://test", "model_uri")
+
+
+def test_download_exception_cleanup():
+    """Test proper cleanup when download fails with exception."""
+
+    class MockNubisonModel:
+        def infer(self, test: str):
+            return test
+
+        def load_model(self, context):
+            pass
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        shared_dir = os.path.join(temp_dir, "shared")
+        path_file = shared_dir + ".path"
+
+        # Ensure no cache exists initially
+        assert not os.path.exists(path_file)
+
+        with patch(
+            "nubison_model.Service._get_shared_artifacts_dir", return_value=shared_dir
+        ):
+            with patch(
+                "nubison_model.Service._load_cached_model_if_available",
+                return_value=None,
+            ):
+                # Mock download to raise exception
                 with patch(
-                    "nubison_model.Service._load_model_with_nubison_wrapper",
-                    side_effect=mock_load_model_wrapper,
+                    "nubison_model.Service._load_model_with_nubison_wrapper"
                 ) as mock_wrapper:
-                    result = load_nubison_mlflow_model("http://test", "original_uri")
+                    mock_wrapper.side_effect = RuntimeError("Download failed")
 
-                    # Should use cached path, not original URI
-                    mock_wrapper.assert_called_once_with("http://test", cached_path)
-                    assert isinstance(result, NubisonMLFlowModel)
+                    # Should raise the download exception
+                    with pytest.raises(RuntimeError, match="Download failed"):
+                        load_nubison_mlflow_model("http://test", "model_uri")
 
-                    # No downloads should have occurred
-                    assert download_count == 0
+                    # Verify no partial cache file was created
+                    assert not os.path.exists(path_file)
+
+        # Test exception during cache path extraction
+        with patch(
+            "nubison_model.Service._get_shared_artifacts_dir", return_value=shared_dir
+        ):
+            with patch(
+                "nubison_model.Service._load_cached_model_if_available",
+                return_value=None,
+            ):
+                with patch(
+                    "nubison_model.Service._load_model_with_nubison_wrapper"
+                ) as mock_wrapper:
+                    mock_wrapper.return_value = (
+                        MagicMock(),
+                        NubisonMLFlowModel(MockNubisonModel()),
+                    )
+
+                    # Mock cache extraction to fail
+                    with patch(
+                        "nubison_model.Service._extract_and_cache_model_path"
+                    ) as mock_extract:
+                        mock_extract.side_effect = OSError("Disk full")
+
+                        # Should raise the extraction exception
+                        with pytest.raises(OSError, match="Disk full"):
+                            load_nubison_mlflow_model("http://test", "model_uri")
+
+                        # Verify no partial cache file was created
+                        assert not os.path.exists(path_file)
 
 
 # Ignore the test_client from being collected by pytest


### PR DESCRIPTION
**Summary**

This PR addresses the issue where MLflow artifacts were being redundantly downloaded for each BentoML worker.

**Changes**

Added a download_mlflow_artifacts function to ensure artifacts are downloaded before the BentoML service starts, so that all workers load from the same pre-downloaded artifacts instead of fetching them individually.

Removed the duplicate-check logic in load_nubison_mlflow_model, since validation of mlflow_tracking_uri and mlflow_model_uri is now handled in download_mlflow_artifacts.

**Result**

Prevents multiple workers from repeatedly downloading the same MLflow artifacts.

Ensures more efficient and consistent artifact loading across workers.



---add (2025.09.18)

Issue
Previously, each BentoML worker independently invoked build_inference_service(), which caused load_nubison_mlflow_model() to redundantly download the same MLflow artifacts. The number of redundant downloads scaled with the number of workers.

Changes in load_nubison_mlflow_model:

Implemented a filesystem lock mechanism.

Ensured that secondary workers wait until the first worker finishes downloading artifacts.

Recorded the artifact path created by Mlflow’s automatic download process into nubison_shared_artifacts.path (using the filesystem).

From the second worker onward, artifacts are loaded directly from the recorded path, preventing redundant downloads.