### PR TITLE
feat: add skip_model_registration option to register()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,58 @@
 # Nubison
 
 This project is a SDK for integrate ML model to Nubison.
+
+## Usage
+
+### Register a model (default)
+
+Logs the experiment and creates a Model Registry entry in one call.
+
+```python
+from nubison_model import register, NubisonModel, ModelContext
+
+
+class MyModel(NubisonModel):
+    def load_model(self, context: ModelContext):
+        ...
+
+    def infer(self, input):
+        ...
+
+
+model_uri = register(
+    MyModel(),
+    model_name="MyModel",
+    artifact_dirs="src,weights",
+    params={"lr": 0.01, "epochs": 100},
+    metrics={"accuracy": 0.95},
+)
+# model_uri == "models:/MyModel/<version>"
+```
+
+### Log experiment only (skip Model Registry)
+
+Pass `skip_model_registration=True` to log the experiment and package the
+model as a run artifact, without creating a Model Registry entry. The
+returned URI has a `runs:/` prefix and can later be registered via
+`mlflow.register_model()`.
+
+```python
+run_uri = register(
+    MyModel(),
+    model_name="MyModel",
+    artifact_dirs="src,weights",
+    params={"lr": 0.01},
+    metrics={"accuracy": 0.95},
+    skip_model_registration=True,
+)
+# run_uri == "runs:/<run_id>/model"
+
+# Later, review results and register when ready:
+import mlflow
+
+mlflow.register_model(run_uri, "MyModel")
+```
+
+The default is `skip_model_registration=False`, which preserves the original
+behavior.

--- a/example/README.md
+++ b/example/README.md
@@ -62,6 +62,10 @@ The `register` function is used to register the user model with MLflow. It suppo
 - `params`: Optional dictionary of parameters to log with the MLflow run.
 - `metrics`: Optional dictionary of metrics to log with the MLflow run.
 - `tags`: Optional dictionary of tags to log with the model version.
+- `skip_model_registration`: When `True`, logs the experiment and packages the
+  model as a run artifact but skips creating a Model Registry entry. The
+  returned URI uses the `runs:/` prefix and can later be registered via
+  `mlflow.register_model(uri, model_name)`. Default: `False`.
 
 ### ### Test a user model
 

--- a/nubison_model/Model.py
+++ b/nubison_model/Model.py
@@ -251,6 +251,7 @@ def register(
     params: Optional[dict[str, Any]] = None,
     metrics: Optional[dict[str, float]] = None,
     tags: Optional[dict[str, str]] = None,
+    skip_model_registration: bool = False,
 ):
     """Register a model with MLflow.
 
@@ -266,10 +267,18 @@ def register(
         artifact_dirs: Comma-separated list of directories to include as artifacts
         params: Optional dictionary of parameters to log
         metrics: Optional dictionary of metrics to log
-        tags: Optional dictionary of tags to log with the model registration
+        tags: Optional dictionary of tags. Always logged on the MLflow run.
+            When skip_model_registration is False, also applied to the Model
+            Registry version (via MlflowClient.set_model_version_tag).
+        skip_model_registration: If True, logs the experiment (params/metrics/tags/
+            artifacts) and packages the model as a run artifact, but skips creating
+            a Model Registry entry. The returned URI has a 'runs:/' prefix and can
+            later be registered via mlflow.register_model(uri, model_name).
+            Default: False (preserves existing behavior).
 
     Returns:
-        str: The URI of the registered model
+        str: The URI of the registered model. When skip_model_registration is False,
+        returns a 'models:/' URI. When True, returns a 'runs:/' URI.
 
     Raises:
         TypeError: If the model doesn't implement the NubisonModel protocol
@@ -329,7 +338,7 @@ def register(
         # Log the model to MLflow
         # Always use folder structure to maintain consistent artifact paths
         model_info: ModelInfo = mlflow.pyfunc.log_model(
-            registered_model_name=model_name,
+            registered_model_name=None if skip_model_registration else model_name,
             python_model=NubisonMLFlowModel(model),
             conda_env=_make_conda_env(),
             artifacts=_make_artifact_dir_dict(artifact_dirs),
@@ -337,7 +346,7 @@ def register(
         )
 
         # Set tags on the registered model version
-        if tags:
+        if tags and not skip_model_registration:
             client = mlflow.tracking.MlflowClient()
             for tag_name, tag_value in tags.items():
                 client.set_model_version_tag(

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,6 +1,8 @@
 from os import path
 
+import mlflow
 import pytest
+from mlflow.exceptions import RestException
 from mlflow.tracking import MlflowClient
 
 from nubison_model import ModelContext, NubisonModel, register
@@ -165,3 +167,93 @@ def test_register_with_tags(mlflow_server):
         assert (
             model_version.tags[tag_name] == tag_value
         ), f"Tag {tag_name} was not set correctly"
+
+
+def test_register_skip_no_registry_entry(mlflow_server):
+    """When skip_model_registration=True, no Model Registry entry is created."""
+    model_name = "TestSkipNoRegistry"
+
+    class DummyModel(NubisonModel):
+        def load_model(self, context: ModelContext):
+            pass
+
+        def infer(self, input):
+            pass
+
+    register(DummyModel(), model_name=model_name, skip_model_registration=True)
+
+    client = MlflowClient()
+    with pytest.raises(RestException):
+        client.get_registered_model(model_name)
+
+
+def test_register_skip_model_still_packaged(mlflow_server):
+    """With skip=True the model is still packaged as a run artifact."""
+    model_name = "TestSkipPackaged"
+
+    class DummyModel(NubisonModel):
+        def load_model(self, context: ModelContext):
+            pass
+
+        def infer(self, input):
+            return input
+
+    artifact_dirs = ["src_skip_packaged"]
+    with temporary_dirs(artifact_dirs), temporary_env(
+        {"ARTIFACT_DIRS": ",".join(artifact_dirs)}
+    ):
+        run_uri = register(
+            DummyModel(),
+            model_name=model_name,
+            skip_model_registration=True,
+        )
+
+    run_id = get_run_id_from_model_uri(run_uri)
+    client = MlflowClient()
+    artifact_path = client.download_artifacts(run_id, "")
+    for d in artifact_dirs:
+        assert path.exists(path.join(artifact_path, "artifacts", d))
+
+
+def test_register_skip_returns_runs_uri(mlflow_server):
+    """When skip=True the returned URI has a 'runs:/' prefix."""
+
+    class DummyModel(NubisonModel):
+        def load_model(self, context: ModelContext):
+            pass
+
+        def infer(self, input):
+            pass
+
+    uri = register(
+        DummyModel(),
+        model_name="TestSkipURI",
+        skip_model_registration=True,
+    )
+    assert uri.startswith("runs:/"), f"Expected 'runs:/' prefix, got: {uri}"
+
+
+def test_register_skip_then_register_via_mlflow_api(mlflow_server):
+    """The returned runs:/ URI can be registered via mlflow.register_model()."""
+    model_name = "TestSkipThenRegister"
+
+    class DummyModel(NubisonModel):
+        def load_model(self, context: ModelContext):
+            pass
+
+        def infer(self, input):
+            pass
+
+    run_uri = register(
+        DummyModel(),
+        model_name=model_name,
+        skip_model_registration=True,
+    )
+
+    mlflow.register_model(run_uri, model_name)
+
+    client = MlflowClient()
+    registered = client.get_registered_model(model_name)
+    assert registered.name == model_name
+
+    client.delete_registered_model(model_name)


### PR DESCRIPTION
  ## Summary                                                                                                         
           
  Add a `skip_model_registration: bool = False` parameter to `register()`.                                           
  When `True`, the function logs the experiment (params / metrics / tags /
  artifacts) and packages the model as a run artifact, but skips creating                                            
  a Model Registry entry. The returned URI uses the `runs:/` prefix and                                              
  can be registered later via `mlflow.register_model(uri, model_name)`.                                              
                                                                                                                     
  ## Why                                                                                                             
                                                                                                                     
  The model registration flow consumed by `mlplatform`                                                               
  (nubison/mlplatform#131) needs to separate "experiment logging" from
  "model registry registration" so that a user can review training results                                           
  before committing a model to the registry.                                                                         
                                                                                                                     
  ## Behavior                                                                                                        
                                                                                                                     
  | Case | Behavior |                          
  | `skip_model_registration=False` (default) | Existing behavior. Logs experiment, registers the model, returns a
  `models:/<name>/<version>` URI. |                                                                               
  | `skip_model_registration=True` | Logs experiment, packages model as a run artifact, returns a                    
  `runs:/<run_id>/...` URI. No Model Registry entry is created. |                                
                                                                                                                     
  The URI returned in the `True` case can be registered later via the
  standard MLflow API:                                                                                               
                      
  \`\`\`python                                                                                                       
  run_uri = register(model, ..., skip_model_registration=True)
  # ... review results ...                                                                                           
  mlflow.register_model(run_uri, "MyModel")                                                                          
  \`\`\`                                                                                                             
                                                                                                                     
  ## Changes                                                                                                         
                                               
  - `nubison_model/Model.py` — new parameter, conditional
    `registered_model_name` pass-through, skip the post-registration tag
    loop when no version exists.                                                                                     
  - `test/test_model.py` — four new tests covering:                                                                  
    - registry entry absent when `skip=True`                                                                         
    - model package still saved to run artifacts                                                                     
    - returned URI has the `runs:/` prefix                                                                           
    - the returned URI is accepted by `mlflow.register_model()`                                                      
  - `README.md` — usage section for both the default path and the                                                    
    experiment-only path.                                                                                            
  - `example/README.md` — document the new parameter in the register()                                               
    argument list.                                                                                                   
                                                                                                                     
  ## Test plan                                 
                                                                                                                     
  - [x] `pytest test/test_model.py -v` → 10 passed (6 existing, 4 new)
  - [x] End-to-end workflow against a real MLflow server (training run                                               
        logs step-wise metrics, `register(skip=True)` does not create a
        registry entry, `mlflow.register_model()` later promotes the same                                            
        run to a registered version)                                                                                 
                                                                                                                     
  ## Non-goals                                                                                                       
                                                                                                                     
  - Active run detection / re-entry                                                                                  
  - `run_id` parameter for reusing a user-managed MLflow run                                                         
  - Wrapping MLflow APIs behind a nubison-model context manager
  - Changes to the existing `register()` default behavior                                                            
                                                                                                                     
  Refs: nubison/mlplatform#131 