### PR TITLE
fix: start_server.sh MLflow 3.x compat

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,19 +1,13 @@
 FROM python:3.12.8-slim-bookworm
 
-# Install necessary dependencies
 RUN apt-get update && apt-get install -y \
     bash \
-    curl \
     python3-opencv \
     && rm -rf /var/lib/apt/lists/*
 
-# Use bash as the default shell
 SHELL ["bash", "-c"]
-
-# Set the working directory
 WORKDIR /app
 
-# Add label descriptions
 LABEL org.opencontainers.image.title="nubison-model" \
       org.opencontainers.image.description="A container image for nubison-model."\
       org.opencontainers.image.source="https://github.com/nubison/nubison-model"
@@ -21,17 +15,17 @@ LABEL org.opencontainers.image.title="nubison-model" \
 COPY start_server.sh /app/start_server.sh
 RUN chmod +x /app/start_server.sh
 
-# Set environment variables with default values
 ENV MLFLOW_TRACKING_URI=""
 ENV MLFLOW_MODEL_URI=""
+ENV MLFLOW_MODEL_NAME=""
+ENV MLFLOW_MODEL_VERSION=""
 ENV DEBUG=""
 ENV PORT=3000
 ENV NUM_WORKERS=2
 
-# Expose the port specified by the PORT environment variable
 EXPOSE ${PORT}
 
-RUN pip install uv==0.5.10
+RUN pip install --no-cache-dir uv==0.5.10 "mlflow-skinny>=3.12.0,<3.14.0" pyyaml && \
+    uv python install 3.9 3.10 3.11 3.12
 
-# Define the command to run your application
 ENTRYPOINT [ "/app/start_server.sh" ]

--- a/container/README.md
+++ b/container/README.md
@@ -1,5 +1,5 @@
 # Container for nubison-model
-It is a container for the nubison-model. It is based on Alpine Linux and Miniforge. It will run the nubison-model server for given model URI.
+It is a container for the nubison-model. It is based on `python:3.12-slim-bookworm` with `uv` and `mlflow-skinny`. It will run the nubison-model server for a given model URI.
 
 ## Build
 
@@ -16,5 +16,24 @@ docker push ghcr.io/nubison/nubison-model:latest
 ## Run
 
 ```bash
-docker run host -e MLFLOW_TRACKING_URI=http://mlflow.host.uri -e MLFLOW_MODEL_URI=runs:/0b8ef6de308842e1ba40f0ae5481f9de/ -e PORT=3000 -e DEBUG=true ghcr.io/nubison/nubison-model:latest
+docker run \
+  -e MLFLOW_TRACKING_URI=http://mlflow.host.uri \
+  -e MLFLOW_MODEL_URI=runs:/0b8ef6de308842e1ba40f0ae5481f9de/model \
+  -e MLFLOW_MODEL_NAME=MyModel \
+  -e MLFLOW_MODEL_VERSION=1 \
+  -e PORT=3000 \
+  -e DEBUG=true \
+  ghcr.io/nubison/nubison-model:latest
 ```
+
+## Environment variables
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `MLFLOW_TRACKING_URI` | yes | MLflow tracking server URI |
+| `MLFLOW_MODEL_URI` | yes | Model URI used by BentoML to load the model (e.g. `runs:/<run_id>/model` or `models:/<name>/<version>`) |
+| `MLFLOW_MODEL_NAME` | yes | Registered model name — used to fetch `conda.yaml` / `requirements.txt` via `models:/<name>/<version>` (MLflow 3.x stores them under LoggedModel entity) |
+| `MLFLOW_MODEL_VERSION` | yes | Registered model version |
+| `PORT` | no (default `3000`) | BentoML HTTP server port |
+| `NUM_WORKERS` | no (default `2`) | BentoML worker count |
+| `DEBUG` | no | If set, passes `--debug` to `bentoml serve` |

--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -1,35 +1,89 @@
 #!/bin/bash
 set -e
 
-# Check if MLFLOW_TRACKING_URI is set
-if [ -z "$MLFLOW_TRACKING_URI" ]; then
-  echo "Error: MLFLOW_TRACKING_URI environment variable is not set."
+log() { echo "[nubison-model] $(date '+%H:%M:%S') $*"; }
+err() { echo "[nubison-model] $(date '+%H:%M:%S') ERROR: $*" >&2; }
+
+# --- Validate required env vars ---
+missing=()
+[ -z "$MLFLOW_TRACKING_URI" ]  && missing+=("MLFLOW_TRACKING_URI")
+[ -z "$MLFLOW_MODEL_URI" ]     && missing+=("MLFLOW_MODEL_URI")
+[ -z "$MLFLOW_MODEL_NAME" ]    && missing+=("MLFLOW_MODEL_NAME")
+[ -z "$MLFLOW_MODEL_VERSION" ] && missing+=("MLFLOW_MODEL_VERSION")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  err "Missing required env vars: ${missing[*]}"
   exit 1
 fi
 
-# Check if MLFLOW_TRACKING_URI is set
-if [ -z "$MLFLOW_MODEL_URI" ]; then
-  echo "Error: MLFLOW_MODEL_URI environment variable is not set."
+log "=== Configuration ==="
+log "  MLFLOW_TRACKING_URI:  $MLFLOW_TRACKING_URI"
+log "  MLFLOW_MODEL_URI:     $MLFLOW_MODEL_URI"
+log "  MLFLOW_MODEL_NAME:    $MLFLOW_MODEL_NAME"
+log "  MLFLOW_MODEL_VERSION: $MLFLOW_MODEL_VERSION"
+log "  NUM_WORKERS:          ${NUM_WORKERS:-2}"
+log "  PORT:                 ${PORT:-3000}"
+
+# --- Download conda.yaml & requirements.txt via MLflow API ---
+ARTIFACT_URI="models:/${MLFLOW_MODEL_NAME}/${MLFLOW_MODEL_VERSION}"
+log "Downloading dependencies from $ARTIFACT_URI ..."
+
+python_version=$(python -c "
+import os, sys, time, shutil, yaml
+from mlflow.artifacts import download_artifacts
+
+artifact_uri = 'models:/' + os.environ['MLFLOW_MODEL_NAME'] + '/' + os.environ['MLFLOW_MODEL_VERSION']
+max_retries = 3
+files = ['/conda.yaml', '/requirements.txt']
+
+for attempt in range(1, max_retries + 1):
+    try:
+        paths = {}
+        for f in files:
+            uri = artifact_uri + f
+            print(f'  Downloading {f[1:]} ...', file=sys.stderr, flush=True)
+            paths[f] = download_artifacts(artifact_uri=uri)
+        break
+    except Exception as e:
+        if attempt == max_retries:
+            print(f'ERROR: Download failed after {max_retries} attempts: {e}', file=sys.stderr)
+            sys.exit(1)
+        wait = attempt * 5
+        print(f'  Attempt {attempt}/{max_retries} failed: {e}', file=sys.stderr)
+        print(f'  Retrying in {wait}s ...', file=sys.stderr, flush=True)
+        time.sleep(wait)
+
+for f, src in paths.items():
+    shutil.copy(src, '/app' + f)
+print('  Dependencies downloaded.', file=sys.stderr, flush=True)
+
+with open('/app/conda.yaml') as f:
+    env = yaml.safe_load(f)
+for dep in env.get('dependencies', []):
+    if isinstance(dep, str) and dep.startswith('python='):
+        print(dep.split('=')[1])
+        break
+else:
+    print('ERROR: python version not found in conda.yaml dependencies', file=sys.stderr)
+    sys.exit(1)
+")
+
+if [ -z "$python_version" ]; then
+  err "Failed to extract Python version from conda.yaml"
   exit 1
 fi
 
-run_uuid=$(echo "$MLFLOW_MODEL_URI" | sed -E 's|runs:/([a-zA-Z0-9]+)/?$|\1|' || echo "")
-ENV_NAME="nubison"
+# major.minor only (e.g. 3.11.12 -> 3.11) — uv doesn't have every patch version
+python_minor="${python_version%.*}"
 
-echo "MLFLOW_TRACKING_URI: '$MLFLOW_TRACKING_URI'"
-echo "MLFLOW_MODEL_URI: '$MLFLOW_MODEL_URI'"
-echo "NUM_WORKERS: '$NUM_WORKERS'"
+log "Detected Python $python_version (using $python_minor)"
+log "Installing Python $python_minor ..."
+uv python install "$python_minor"
 
-echo "Downloading conda.yaml & requirements.txt for run $run_uuid"
-ret_conda=$(curl -L -o conda.yaml -f "${MLFLOW_TRACKING_URI}/get-artifact?path=conda.yaml&run_uuid=${run_uuid}")
-ret_req=$(curl -L -o requirements.txt -f "${MLFLOW_TRACKING_URI}/get-artifact?path=requirements.txt&run_uuid=${run_uuid}")
+# Override MLFLOW_MODEL_URI to models:/ format (runs:/ is deprecated in MLflow 3.x)
+export MLFLOW_MODEL_URI="models:/${MLFLOW_MODEL_NAME}/${MLFLOW_MODEL_VERSION}"
+log "MLFLOW_MODEL_URI overridden to: $MLFLOW_MODEL_URI"
 
-if [ "$ret_conda" -ne 200 ] || [ "$ret_req" -ne 200 ]; then
-  echo "Failed to download conda.yaml or requirements.txt"
-  exit 1
-fi
-
-python_version=$(grep "python=" conda.yaml | awk -F= '{print $2}')
-
-echo "Starting BentoML server..."
-exec uv run --python $python_version --with-requirements requirements.txt bentoml serve nubison_model.Service:InferenceService --port ${PORT} ${DEBUG:+--debug}
+# --- Start BentoML server ---
+log "Starting BentoML server on port ${PORT:-3000} ..."
+exec uv run --python "$python_minor" --with-requirements requirements.txt bentoml serve nubison_model.Service:InferenceService --port "${PORT}" ${DEBUG:+--debug}

--- a/container/start_server.sh
+++ b/container/start_server.sh
@@ -5,9 +5,10 @@ log() { echo "[nubison-model] $(date '+%H:%M:%S') $*"; }
 err() { echo "[nubison-model] $(date '+%H:%M:%S') ERROR: $*" >&2; }
 
 # --- Validate required env vars ---
+# Note: MLFLOW_MODEL_URI is constructed from NAME+VERSION below (models:/ form),
+# so it is not required as input.
 missing=()
 [ -z "$MLFLOW_TRACKING_URI" ]  && missing+=("MLFLOW_TRACKING_URI")
-[ -z "$MLFLOW_MODEL_URI" ]     && missing+=("MLFLOW_MODEL_URI")
 [ -z "$MLFLOW_MODEL_NAME" ]    && missing+=("MLFLOW_MODEL_NAME")
 [ -z "$MLFLOW_MODEL_VERSION" ] && missing+=("MLFLOW_MODEL_VERSION")
 
@@ -15,6 +16,11 @@ if [ ${#missing[@]} -gt 0 ]; then
   err "Missing required env vars: ${missing[*]}"
   exit 1
 fi
+
+# Build models:/ URI used both for artifact download and BentoML model loading.
+# Ignore any inbound MLFLOW_MODEL_URI (e.g. legacy runs:/ form) — MLflow 3.x
+# stores pyfunc artifacts under a LoggedModel entity and runs:/ is deprecated.
+export MLFLOW_MODEL_URI="models:/${MLFLOW_MODEL_NAME}/${MLFLOW_MODEL_VERSION}"
 
 log "=== Configuration ==="
 log "  MLFLOW_TRACKING_URI:  $MLFLOW_TRACKING_URI"
@@ -25,14 +31,13 @@ log "  NUM_WORKERS:          ${NUM_WORKERS:-2}"
 log "  PORT:                 ${PORT:-3000}"
 
 # --- Download conda.yaml & requirements.txt via MLflow API ---
-ARTIFACT_URI="models:/${MLFLOW_MODEL_NAME}/${MLFLOW_MODEL_VERSION}"
-log "Downloading dependencies from $ARTIFACT_URI ..."
+log "Downloading dependencies from $MLFLOW_MODEL_URI ..."
 
 python_version=$(python -c "
 import os, sys, time, shutil, yaml
 from mlflow.artifacts import download_artifacts
 
-artifact_uri = 'models:/' + os.environ['MLFLOW_MODEL_NAME'] + '/' + os.environ['MLFLOW_MODEL_VERSION']
+artifact_uri = os.environ['MLFLOW_MODEL_URI']
 max_retries = 3
 files = ['/conda.yaml', '/requirements.txt']
 
@@ -73,16 +78,13 @@ if [ -z "$python_version" ]; then
   exit 1
 fi
 
-# major.minor only (e.g. 3.11.12 -> 3.11) — uv doesn't have every patch version
-python_minor="${python_version%.*}"
+# major.minor only (e.g. 3.11.12 -> 3.11) — uv doesn't ship every patch version.
+# Use cut to be safe when conda.yaml has only major.minor (e.g. "3.11").
+python_minor=$(echo "$python_version" | cut -d. -f1,2)
 
 log "Detected Python $python_version (using $python_minor)"
 log "Installing Python $python_minor ..."
 uv python install "$python_minor"
-
-# Override MLFLOW_MODEL_URI to models:/ format (runs:/ is deprecated in MLflow 3.x)
-export MLFLOW_MODEL_URI="models:/${MLFLOW_MODEL_NAME}/${MLFLOW_MODEL_VERSION}"
-log "MLFLOW_MODEL_URI overridden to: $MLFLOW_MODEL_URI"
 
 # --- Start BentoML server ---
 log "Starting BentoML server on port ${PORT:-3000} ..."

--- a/example/infer_lightning.ipynb
+++ b/example/infer_lightning.ipynb
@@ -84,7 +84,7 @@
     "model_id = register(\n",
     "    UserModel(),\n",
     "    artifact_dirs=\"src\",\n",
-    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.6\"},\n",
+    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.7\"},\n",
     ")\n",
     "print(f\"Model registered: {model_id}\")\n"
    ]

--- a/example/infer_pytorch.ipynb
+++ b/example/infer_pytorch.ipynb
@@ -85,7 +85,7 @@
     "model_id = register(\n",
     "    UserModel(),\n",
     "    artifact_dirs=\"src\",\n",
-    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.6\"},\n",
+    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.7\"},\n",
     ")\n",
     "print(f\"Model registered: {model_id}\")\n"
    ]

--- a/example/infer_sklearn.ipynb
+++ b/example/infer_sklearn.ipynb
@@ -80,7 +80,7 @@
     "model_id = register(\n",
     "    UserModel(),\n",
     "    artifact_dirs=\"src\",\n",
-    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.6\"},\n",
+    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.7\"},\n",
     ")\n",
     "print(f\"Model registered: {model_id}\")\n"
    ]

--- a/example/infer_transformers.ipynb
+++ b/example/infer_transformers.ipynb
@@ -87,7 +87,7 @@
     "model_id = register(\n",
     "    UserModel(),\n",
     "    artifact_dirs=\"src\",\n",
-    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.6\"},\n",
+    "    tags={\"inference_server_image\": \"ghcr.io/nubison/nubison-model:0.0.7\"},\n",
     ")\n",
     "print(f\"Model registered: {model_id}\")\n"
    ]


### PR DESCRIPTION
## Summary

- `container/start_server.sh`: replace curl-based `conda.yaml` / `requirements.txt` download with `mlflow.artifacts.download_artifacts()` Python API. MLflow 3.x stores `pyfunc.log_model()` artifacts under a per-run LoggedModel entity, so the old `/get-artifact?path=conda.yaml&run_uuid=...` endpoint returns 404/500.
- Construct `models:/{name}/{version}` URI from `MLFLOW_MODEL_NAME` + `MLFLOW_MODEL_VERSION` env vars. `MLFLOW_MODEL_URI` is no longer required as input — it is always built from NAME + VERSION. Any legacy `runs:/` value passed by the deployer is ignored.
- Docker image slimmed: `mlflow` -> `mlflow-skinny` (**2.08GB -> 1.47GB**), pre-install Python 3.9 / 3.10 / 3.11 / 3.12 via `uv` at build time (saves ~5s on every cold start).
- Add 3-attempt retry with linear backoff (5s, 10s, 15s) for transient MLflow failures; structured timestamped logs.
- `uv` does not ship every patch version, so fall back to `major.minor` (`3.11.12` -> `3.11`) using `cut -d. -f1,2` for safe parsing.
- Bump `inference_server_image` tag `0.0.6` -> `0.0.7` in the four `example/infer_*.ipynb` notebooks.
- Update `container/README.md`: correct base image (it is `python:3.12-slim-bookworm`, not Alpine/Miniforge) and document required env vars.

## Background

mlplatform #321 validation-deploy injects these env vars into the K8s Deployment:

- `MLFLOW_TRACKING_URI`: in-cluster MLflow URL
- `MLFLOW_MODEL_NAME`, `MLFLOW_MODEL_VERSION`: registered model coordinates
- (optional) `MLFLOW_MODEL_URI`: legacy `runs:/` form — now ignored by start_server.sh

Issue: `.issues/start-server-mlflow3-compat.md`

## Test plan

- [ ] Deploy `ghcr.io/nubison/nubison-model:0.0.7` to mlplatform staging
- [ ] Confirm `start_server.sh` downloads `conda.yaml` / `requirements.txt` without 404/500
- [ ] Confirm BentoML server starts and `/infer` responds
- [ ] Verify with `conda.yaml` pinned to Python 3.9 / 3.10 / 3.11 / 3.12